### PR TITLE
upgrades Julia 0.5.1 - Plotly 0.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM julia:0.5.0
+FROM julia:0.5.1
 
 RUN apt-get update && apt-get install -y bash curl git coreutils unzip build-essential cmake
 
-RUN julia -ie 'Pkg.clone("https://github.com/nextjournal/PlotlyJS.jl.git"); using PlotlyJS'
+RUN julia -ie 'Pkg.clone("https://github.com/nextjournal/PlotlyJS.jl.git"); Pkg.checkout("PlotlyJS", "nj0.5.2"); using PlotlyJS'
 RUN julia -ie 'Pkg.add("Distributions", v"0.11.1"); using Distributions'
 RUN julia -ie 'Pkg.add("Requests", v"0.3.11"); using Requests'
 RUN julia -ie 'Pkg.add("DataFrames", v"0.8.5"); using DataFrames'

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,5 @@ FROM julia:0.5.1
 
 RUN apt-get update && apt-get install -y bash curl git coreutils unzip build-essential cmake
 
-RUN julia -ie 'Pkg.clone("https://github.com/nextjournal/PlotlyJS.jl.git"); Pkg.checkout("PlotlyJS", "nj0.5.2"); using PlotlyJS'
-RUN julia -ie 'Pkg.add("Distributions", v"0.11.1"); using Distributions'
-RUN julia -ie 'Pkg.add("Requests", v"0.3.11"); using Requests'
+RUN julia -ie 'Pkg.clone("https://github.com/nextjournal/PlotlyJS.jl.git");  Pkg.checkout("PlotlyJS", "nj0.5.2");  using PlotlyJS'
 RUN julia -ie 'Pkg.add("DataFrames", v"0.8.5"); using DataFrames'

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,13 @@ FROM julia:0.5.1
 
 RUN apt-get update && apt-get install -y bash curl git coreutils unzip build-essential cmake
 
-RUN julia -ie 'Pkg.clone("https://github.com/nextjournal/PlotlyJS.jl.git");  Pkg.checkout("PlotlyJS", "nj0.5.2");  using PlotlyJS'
-RUN julia -ie 'Pkg.add("DataFrames", v"0.8.5"); using DataFrames'
+RUN julia -e 'Pkg.add("DataFrames", v"0.8.5"); using DataFrames'
+ARG PLOTLYJSJLTAG='nj1-0.5.2'
+
+RUN julia -e 'Pkg.clone("https://github.com/nextjournal/PlotlyJS.jl.git")' && \
+  PKG_DIR="$(julia -e 'print(Pkg.dir())')" && \
+  cd "${PKG_DIR}/PlotlyJS" && \
+  git checkout ${PLOTLYJSJLTAG} && \
+  git checkout -b "${PLOTLYJSJLTAG}-branch" && \
+  julia -e 'Pkg.checkout("PlotlyJS", ENV["PLOTLYJSJLTAG"] * "-branch", merge=false, pull=false)' && \
+  julia -e 'using PlotlyJS'

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM julia:0.5.1
 RUN apt-get update && apt-get install -y bash curl git coreutils unzip build-essential cmake
 
 RUN julia -e 'Pkg.add("DataFrames", v"0.8.5"); using DataFrames'
-ARG PLOTLYJSJLTAG='nj1-0.5.2'
+ARG PLOTLYJSJLTAG='a1846adfcf9b3ecf52a1ede7461d698983b808c4'
 
 RUN julia -e 'Pkg.clone("https://github.com/nextjournal/PlotlyJS.jl.git")' && \
   PKG_DIR="$(julia -e 'print(Pkg.dir())')" && \


### PR DESCRIPTION
this will allow to use plotly 0.5.2

I branched off in our fork of [PlotlyJS.jl](https://github.com/nextjournal/PlotlyJS.jl)
but I wouldn't merge that in master so that we can track updates and mirror
them in the Dockerfile (and hence the SHA) of this repo.

It seems we can only use checkout with a real branch and not a tag
with Julia package library.

what do you think, any thoughts on the naming convention?